### PR TITLE
Fixed improper Icon scaling on TargetNameplate

### DIFF
--- a/CombatAssistIcon.lua
+++ b/CombatAssistIcon.lua
@@ -823,7 +823,11 @@ function AssistedCombatIconMixin:UpdateAnchorPoint()
     if db.position.parentFrame == "__nameplate" then
         local nameplate = C_NamePlate.GetNamePlateForUnit("target")
         if nameplate and not nameplate:IsForbidden() and UnitCanAttack("player", "target") then
-            parent = nameplate
+            self:ClearAllPoints()
+            self:SetParent(UIParent)
+            self:SetScale(db.icon.scale)
+            self:SetPoint(point, nameplate, relativePoint, X, Y)
+            return
         end
     elseif db.position.parentFrame == "__cursor" then
         local cursorX, cursorY = GetCursorPosition()


### PR DESCRIPTION
When utilizing the TargetNameplate as the frame parent, there's a bug with the scaling. It scales to sizes that are all over the place. I've seen it get to half the size of my screen!

```
self:SetScale(db.icon.scale * ((uiScale / parent:GetEffectiveScale()) or 1))
```

This math is fine for static anchors, but Nameplates (especially with addons) can scale based on multiple factors. 

The actual bug is due to a race condition between PLAYER_TARGET_CHANGED & NAMEPLATE_UNIT_ADDED. When UpdateAnchorPoint() is called and you're getting the effective scale of the new parent (Nameplate), GetEffectiveScale() isn't calculated yet, so it defaults to an incorrect value.

This fix just bypasses parenting the frame to the Nameplate, and just positions based on the nameplate, and just scales based on the user's set scale. This also doesn't mess with other parenting types.