### PR TITLE
Fixed an issues where DataBroker was not updating correctly

### DIFF
--- a/CombatAssistIcon.lua
+++ b/CombatAssistIcon.lua
@@ -634,6 +634,7 @@ function AssistedCombatIconMixin:OnEvent(event, ...)
 end
 
 function AssistedCombatIconMixin:Start()
+    addon:UpdateBroker()
     if self.ticker or not self.db.enabled then return end
 
     self.ticker = C_Timer.NewTicker(self.updateInterval,function()
@@ -643,6 +644,7 @@ end
 
 function AssistedCombatIconMixin:Stop()
     self:SetShown(false)
+    addon:UpdateBroker()
     if not self.ticker then return end
 
     self.ticker:Cancel()

--- a/Core.lua
+++ b/Core.lua
@@ -1251,25 +1251,22 @@ function addon:SetupOptions()
         func = function() AceConfigDialog:Open(addonName) end
     })
 
-    local function DataBrokerLabel()
-        if addon.db.profile.enabled then
-            return PREFIX .. "(|c0000ff00Enabled|r)"
-        else
-            return PREFIX .. "(|c00ff0000Disabled|r)"
-        end
-    end
-
     addon.DataBroker = LDB:NewDataObject(addonName,{
         type = "launcher",
         text = nil,
-        label = DataBrokerLabel(),
+        label = addon:DataBrokerLabel(),
         icon = addonIcon,
         OnClick = function(self, button, ...)
             if button and button == "RightButton" then
                 addon.db.profile.enabled = not addon.db.profile.enabled
+                if addon.db.profile.enabled then
+                    AssistedCombatIconFrame:Start()
+                else
+                    AssistedCombatIconFrame:Stop()
+                end
+
                 AssistedCombatIconFrame:UpdateVisibility()
 
-                addon.DataBroker.label = DataBrokerLabel()
                 if AceConfigDialog.OpenFrames[addonName] then
                     AceConfigRegistry:NotifyChange(addonName)
                 end
@@ -1290,6 +1287,18 @@ function addon:SetupOptions()
             GameTooltip:Hide()
         end
     })
+end
+
+function addon:DataBrokerLabel()
+    if addon.db.profile.enabled then
+        return PREFIX .. "(|c0000ff00Enabled|r)"
+    else
+        return PREFIX .. "(|c00ff0000Disabled|r)"
+    end
+end
+
+function addon:UpdateBroker()
+    addon.DataBroker.label = addon:DataBrokerLabel()
 end
 
 function addon:OnProfileChanged()


### PR DESCRIPTION
When addon started disabled and was enabled from the DataBroker, the addon never started. Updated the DataBroker to start/stop the addon when changing the enabled status.

When the addon was enabled/disabled from the options menu, the DataBroker was not updated. Created an UpdateBroker method to update the broker any time Start() or Stop() is called.